### PR TITLE
docs: fix README links to upgrade and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ selecting data from the Store.
 
 ## Upgrade Guide 7.1.x to 7.3.1
 
-[API Comparison | The new Decorator API](https://github.com/co-IT/co-it/blob/master/ngrx/ducks/docs/migration.md)
+[API Comparison | The new Decorator API](https://github.com/co-IT/ngrx-ducks/blob/master/packages/ducks/docs/migration.md)
 
 ## Quick Start
 
-[Getting started in 10 Minutes](https://github.com/co-IT/co-it/blob/master/ngrx/ducks/docs/quick-start.md).
+[Getting started in 10 Minutes](https://github.com/co-IT/ngrx-ducks/blob/master/packages/ducks/docs/quick-start.md).
 
 ## Demo
 


### PR DESCRIPTION
Upgrade and Quick Start links are broken