### PR TITLE
fix(@ducksify): set initial state

### DIFF
--- a/packages/core/src/decorator-api/decorators/ducksify.decorator.ts
+++ b/packages/core/src/decorator-api/decorators/ducksify.decorator.ts
@@ -1,21 +1,19 @@
 import { ɵɵdefineInjectable, ɵɵinject } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { ducksify } from '../ducks';
 import { notConstructableError } from '../../store-facade/store-facade';
+import { ducksify } from '../ducks';
 import { AnnotationTarget, DucksifyConfig } from '../typings';
 import { InitialState } from './initial-state.decorator';
 
 export function Ducksify<T>(config: DucksifyConfig<T>) {
   return function(constructor: AnnotationTarget) {
+    InitialState(config.initialState)(constructor);
     constructor.ɵfac = notConstructableError;
     constructor.ɵprov = ɵɵdefineInjectable({
       token: constructor,
       providedIn: 'root',
       factory() {
-        return ducksify(
-          InitialState(config.initialState)(constructor),
-          ɵɵinject(Store)
-        );
+        return ducksify(constructor, ɵɵinject(Store));
       }
     });
 


### PR DESCRIPTION
Hi!

After upgrading to `@ngrx-ducks/core@9.0.0-rc.2` I get the following error when I use the `@Ducksify` decorator:

`Error: ngrx-ducks > reducerFrom: MyDuck does not define initialValue. Make sure to annotate MyDuck with @InitialState.`

This PR fixes this. Somehow it is too late to set the `InitialState` inside `factory`, I moved this part to the beginning of the function.

Everything else worked like a charm after upgrading to `@ngrx-ducks/core@9.0.0-rc.2`, I can still use the old decorator API (but I am looking forward to use the new API)! 🎉 