### PR TITLE
fix(store-chunk): allow constructor arguments on decorated classes

### DIFF
--- a/libs/core/src/lib/store-chunk/annotation-target.ts
+++ b/libs/core/src/lib/store-chunk/annotation-target.ts
@@ -1,5 +1,5 @@
 export interface AnnotationTarget {
-  new (): InstanceType<any>;
+  new (...args: any[]): InstanceType<any>;
   ɵfac?: Function;
   ɵprov?: any;
 }

--- a/libs/core/src/lib/store-chunk/store-chunk.types.spec.ts
+++ b/libs/core/src/lib/store-chunk/store-chunk.types.spec.ts
@@ -3,16 +3,16 @@ import { compilerOptions } from '../utils';
 import { StoreChunk } from './store-chunk';
 
 describe(StoreChunk.name, () => {
+  const expectSnippet = expecter(
+    code => `
+      import { StoreChunk } from '@ngrx-ducks/core';
+      ${code}
+    `,
+    compilerOptions()
+  );
+
   describe('When the decorator is used with generic type parameter specifies the defaults', () => {
     it('passes if the defaults are provided correctly', () => {
-      const expectSnippet = expecter(
-        code => `
-          import { StoreChunk } from '@ngrx-ducks/core';
-          ${code}
-        `,
-        compilerOptions()
-      );
-
       expectSnippet(`
         interface CounterState {
           count: number;
@@ -20,6 +20,17 @@ describe(StoreChunk.name, () => {
 
         @StoreChunk<CounterState>({ feature: 'counter', defaults: { count: 0 } })
         class Counter {}
+      `).toSucceed();
+    });
+  });
+
+  describe('When the decorator is used on a class with constructor arguments', () => {
+    it('passes', () => {
+      expectSnippet(`
+        @StoreChunk()
+        class Counter {
+          constructor(dep: any){}
+        }
       `).toSucceed();
     });
   });


### PR DESCRIPTION
fixes #68