### PR TITLE
feat: use namespace to merge actions property into CounterStore

### DIFF
--- a/apps/ngrx-ducks/src/app/counter/store/counter/counter.effects.ts
+++ b/apps/ngrx-ducks/src/app/counter/store/counter/counter.effects.ts
@@ -1,17 +1,17 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { delay, map } from 'rxjs/operators';
-import { counterStoreChunkActions } from './counter.store';
+import { CounterStore } from './counter.store';
 
 @Injectable()
 export class CounterEffects {
   setCounter = createEffect(() =>
     this.actions$.pipe(
-      ofType(counterStoreChunkActions.loadCount),
+      ofType(CounterStore.actions.loadCount),
       delay(2000),
-      map(({ payload }) => counterStoreChunkActions.override(payload))
+      map(({ payload }) => CounterStore.actions.override(payload))
     )
   );
 
-  constructor(private actions$: Actions) { }
+  constructor(private actions$: Actions) {}
 }

--- a/apps/ngrx-ducks/src/app/counter/store/counter/counter.store.ts
+++ b/apps/ngrx-ducks/src/app/counter/store/counter/counter.store.ts
@@ -21,9 +21,7 @@ const initialState = {
   defaults: initialState
 })
 export class CounterStore {
-  static
-
-    pick = useSelect();
+  static pick = useSelect();
   select = useSelectors(selectors);
 
   /**
@@ -62,5 +60,8 @@ export class CounterStore {
   };
 }
 
-
-export const counterStoreChunkActions = useActions(CounterStore, { prefix: counterFeatureName });
+export namespace CounterStore {
+  export const actions = useActions(CounterStore, {
+    prefix: counterFeatureName
+  });
+}


### PR DESCRIPTION
Hi @GregOnNet ,

I had another idea for the problem in https://github.com/co-IT/ngrx-ducks/issues/85 (regarding https://github.com/microsoft/TypeScript/issues/51570).

We could use a namespace to merge the actions property into the store class. In this way, from the outside it is not distinguishable from a static property.

What do you think?